### PR TITLE
Update maven-pmd-plugin version in Documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add [this repo](http://repo.adobe.com/) and then...
 	<plugin>
 	    <groupId>org.apache.maven.plugins</groupId>
 	    <artifactId>maven-pmd-plugin</artifactId>
-	    <version>3.0.1</version>
+	    <version>3.6</version>
 	    <configuration>
 	        <rulesets>
 	            <ruleset>acs/pmd/rules.xml</ruleset>


### PR DESCRIPTION
**maven-pmd-plugin version 3.0.1 does not support JDK 1.8:**
Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.0.1:pmd (default-cli) An error has occurred in PMD Report report generation.: Unsupported targetJdk value '1.8'.

**maven-pmd-plugin Latest Version does not support the current ruleset:**
Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.12.0:pmd (default-cli) Execution default-cli of goal org.apache.maven.plugins:maven-pmd-plugin:3.12.0:pmd failed: Unable to exclude rules [UselessParentheses]; perhaps the rule name is mispelled?

**maven-pmd-plugin version 3.6 supports JDK 1.8 and allows the current ruleset.**

This change will allow users to use the Adobe recommended Java 8 and not fail due to the outdated ruleset. 

Future changes should be to the ruleset, ensuring the latest version of PMD and the maven-pmd-plugin is supported.

**Validated with**
Versions:
Apache Maven 3.5.0
Java version: 1.8.0_202, vendor: Oracle Corporation
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.6", arch: "x86_64", family: "mac"

Command:
mvn pmd:pmd -Panalysis

Plugin Configs:
~~~~
    <profile>
      <id>analysis</id>
          ...
          <plugin>
            <artifactId>maven-pmd-plugin</artifactId>
            <version>[3.0.1 | 3.6 | 3.12.0]</version>
            <executions>
              <execution>
                <phase>package</phase>
                <goals>
                  <goal>pmd</goal>
                  <goal>cpd</goal>
                  <!-- build will fail on warnings -->
                  <goal>check</goal>
                </goals>
              </execution>
            </executions>
          </plugin>
           ...
    </profile>
~~~~
If a different JDK version is needed, `<targetJdk>[1.6 | 1.7 | etc]</targetJdk>` can be used.

*Example:*
~~~~
        <configuration>
          <targetJdk>1.6</targetJdk>
        </configuration>
~~~~
Link: https://maven.apache.org/plugins/maven-pmd-plugin/examples/targetJdk.html#